### PR TITLE
Ignore popping if the topmost route is a modal

### DIFF
--- a/lib/flow_builder.dart
+++ b/lib/flow_builder.dart
@@ -146,6 +146,9 @@ class _FlowBuilderState<T> extends State<FlowBuilder<T>> {
   }
 
   Future<bool> _pop() async {
+    if (ModalRoute.of(context)?.isCurrent == false) {
+      return false;
+    }
     if (mounted) {
       final popHandled = await _navigator?.maybePop() ?? false;
       if (popHandled) return true;


### PR DESCRIPTION
When pushing modals from within FlowBuilder, it shouldn't intercept the pop if the topmost route is the modal.

## Status

**READY/IN DEVELOPMENT/HOLD**

## Breaking Changes

NO

## Description

Ignore popping if the topmost route is a modal.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Testing
